### PR TITLE
Deploy for serving Nexus Graph

### DIFF
--- a/.github/actions/create-mvn-settings/action.yml
+++ b/.github/actions/create-mvn-settings/action.yml
@@ -1,5 +1,20 @@
+# Copyright Paion Data
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 'settings.xml'
 description: 'Generate settings.xml for authenticating internal model package download'
+
 inputs:
   nexus-server-id:
     description: 'Nexus server ID'
@@ -10,6 +25,7 @@ inputs:
   nexus-token:
     description: 'Nexus token'
     required: true
+
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,26 +32,8 @@ env:
   ASTRAIOS_MODEL_PACKAGE_REPO_URL: ${{ secrets.ASTRAIOS_MODEL_PACKAGE_REPO_URL }}
 
 jobs:
-  yaml-lint:
-    name: YAML Style Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actionshub/yamllint@main
-  markdown-lint:
-    name: Markdown Style Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actionshub/markdownlint@main
-  markdown-link-check:
-    name: Markdown Link Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          use-verbose-mode: "yes"
+  yml-md-style:
+    uses: paion-data/github-actions-workflows/.github/workflows/yml-and-md-style-checks.yml@master
 
   tests:
     name: Unit & Integration Tests

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,7 +37,7 @@ jobs:
 
   tests:
     name: Unit & Integration Tests
-    needs: [yaml-lint, markdown-lint, markdown-link-check]
+    needs: yml-md-style
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,7 +50,8 @@ jobs:
           distribution: ${{ env.JDK_DISTRIBUTION }}
       - name: Set up Docker for Integration Tests
         uses: docker-practice/actions-setup-docker@master
-      - uses: ./.github/actions/create-mvn-settings
+      - name: Generate Maven settings.xml
+        uses: ./.github/actions/create-mvn-settings
         with:
           nexus-server-id: ${{ secrets.NEXUS_SERVER_ID }}
           nexus-user: ${{ secrets.NEXUS_USER }}
@@ -82,7 +83,8 @@ jobs:
       - name: Build documentations
         working-directory: docs
         run: yarn build
-      - uses: ./.github/actions/create-mvn-settings
+      - name: Generate Maven settings.xml
+        uses: ./.github/actions/create-mvn-settings
         with:
           nexus-server-id: ${{ secrets.NEXUS_SERVER_ID }}
           nexus-user: ${{ secrets.NEXUS_USER }}
@@ -114,7 +116,7 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: ${{ env.JDK_DISTRIBUTION }}
-      - name: Generate settings.xml
+      - name: Generate Maven settings.xml
         uses: ./.github/actions/create-mvn-settings
         with:
           nexus-server-id: ${{ secrets.NEXUS_SERVER_ID }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,7 +122,7 @@ jobs:
 
   hashicorp:
     name: Generated Webservice WAR in GitHub Action, and Publish Astraios AMI Image and Deploy it to EC2 through HashiCorp
-    # needs: tests
+    needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-name: Template CI/CD
+name: Astraios CI/CD
 
 "on":
   pull_request:
@@ -120,9 +120,9 @@ jobs:
           user_name: ${{ env.USER }}
           user_email: ${{ env.EMAIL }}
 
-  docker-image:
-    name: Build Test & Release Development Docker Image
-    needs: tests
+  hashicorp:
+    name: Generated Webservice WAR in GitHub Action, and Publish Astraios AMI Image and Deploy it to EC2 through HashiCorp
+    # needs: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -132,57 +132,30 @@ jobs:
         with:
           java-version: ${{ env.JDK_VERSION }}
           distribution: ${{ env.JDK_DISTRIBUTION }}
-      - uses: ./.github/actions/create-mvn-settings
+      - name: Generate settings.xml
+        uses: ./.github/actions/create-mvn-settings
         with:
           nexus-server-id: ${{ secrets.NEXUS_SERVER_ID }}
           nexus-user: ${{ secrets.NEXUS_USER }}
           nexus-token: ${{ secrets.NEXUS_TOKEN }}
-      - name: Build App WAR file so that Docker can pickup during image build
-        run: mvn clean package
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Test image build
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: false
-      - name: Login to DockerHub
-        if: github.ref == 'refs/heads/master'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Push image to DockerHub
-        if: github.ref == 'refs/heads/master'
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/astraios:latest
-
-  hashicorp:
-    name: Publish Jersey WS AMI Image and Deploy it to EC2 through HashiCorp
-    needs: tests
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: hashicorp
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Load deployment environment variables into Terraform variable file
+      - name: Load webservice settings
         run: |
-          touch instances/variables.auto.tfvars
-          echo 'zone_id = "${{ secrets.ZONE_ID }}"' > instances/variables.auto.tfvars
-          echo 'sentry_dsn = "${{ secrets.SENTRY_DSN }}"' >> instances/variables.auto.tfvars
-      - name: Load SSL Certificates
+          echo "${{ secrets.APPLICATION_PROPERTIES }}" > src/main/resources/application.properties
+          echo "${{ secrets.JPADATASTORE_PROPERTIES }}" > src/main/resources/jpadatastore.properties
+      - name: Generate webservice WAR file
+        run: mvn -B clean package
+      - name: Load SSL Certificates into AMI
         working-directory: hashicorp/images
         run: |
           echo '${{ secrets.SSL_CERTIFICATE }}' > server.crt
           echo '${{ secrets.SSL_CERTIFICATE_KEY }}' > server.key
-      - name: Publish Jersey WS AMI image and deploy it to EC2 through HashiCorp
+      - name: Load runtime settings into Terraform variable file
+        working-directory: hashicorp/instances
+        run: |
+          touch variables.auto.tfvars
+          echo 'zone_id = "${{ secrets.ZONE_ID }}"' > variables.auto.tfvars
+          echo 'sentry_dsn = "${{ secrets.SENTRY_DSN }}"' >> variables.auto.tfvars
+      - name: Push AMI and Deploy EC2
         uses: QubitPi/aergia@master
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ We Believe Binding to Standard Makes the Best Software
 ------------------------------------------------------
 
 CRUD web services are now widespread, standardizing organizational approaches to the cloud. But as business expand,
-web service often struggle to reach the desired levels of scale. Development slows as complexity growth.
+web service often struggle to reach the desired levels of scale. Development slows as complexity grows.
 
 By codifying and standardizing a webservice development and compliance rules, developers can be free to do what they
 want to: add business value by writing code.
@@ -61,8 +61,8 @@ project more likely. Astraios does more to make itself easy to use by
 - enabling "on-click" experience that goes from nothing to a full-fledged webservice on AWS cloud
 - delegating JPA persistence to [Yahoo Elide] so that the API of Astraios help developers use it correctly.
 
-Documentation
--------------
+Start Using Astraios
+--------------------
 
 - [Documentation]
 - [Javadoc]

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -5,5 +5,4 @@
      "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
 
 <suppressions>
-
 </suppressions>

--- a/hashicorp/images/nexusgraph-astraios.pkr.hcl
+++ b/hashicorp/images/nexusgraph-astraios.pkr.hcl
@@ -22,11 +22,9 @@ packer {
 }
 
 source "amazon-ebs" "astraios" {
-  ami_name = "astraios"
+  ami_name = "nexusgraph-astraios"
   force_deregister = "true"
   force_delete_snapshot = "true"
-
-  ami_groups = ["all"]
 
   instance_type = "t2.small"
   region = "${var.aws_image_region}"
@@ -47,6 +45,28 @@ build {
   sources = [
     "source.amazon-ebs.astraios"
   ]
+
+  # Load SSL Certificates into AMI image
+  provisioner "file" {
+    source = "./server.crt"
+    destination = "/home/ubuntu/server.crt"
+  }
+  provisioner "file" {
+    source = "./server.key"
+    destination = "/home/ubuntu/server.key"
+  }
+
+  # Load Nginx config file into AMI image
+  provisioner "file" {
+    source = "./nginx-ssl.conf"
+    destination = "/home/ubuntu/nginx-ssl.conf"
+  }
+
+  # Load Astraios WAR file into AMI image
+  provisioner "file" {
+    source = "../../target/astraios-1.0-SNAPSHOT.war"
+    destination = "/home/ubuntu/ROOT.war"
+  }
 
   provisioner "shell" {
     script = "../scripts/setup.sh"

--- a/hashicorp/images/nginx-ssl.conf
+++ b/hashicorp/images/nginx-ssl.conf
@@ -1,0 +1,40 @@
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server;
+
+	root /var/www/html;
+
+	index index.html index.htm index.nginx-debian.html;
+
+	server_name _;
+
+	location / {
+		try_files $uri $uri/ =404;
+	}
+}
+
+server {
+	root /var/www/html;
+
+	index index.html index.htm index.nginx-debian.html;
+    server_name astraios.nexusgraph.com;
+
+	location / {
+		proxy_pass http://localhost:8080;
+	}
+
+    listen [::]:443 ssl ipv6only=on;
+    listen 443 ssl;
+    ssl_certificate /etc/ssl/certs/server.crt;
+    ssl_certificate_key /etc/ssl/private/server.key;
+}
+server {
+    if ($host = astraios.nexusgraph.com) {
+        return 301 https://$host$request_uri;
+    }
+
+	listen 80 ;
+	listen [::]:80 ;
+    server_name astraios.nexusgraph.com;
+    return 404;
+}

--- a/hashicorp/instances/main.tf
+++ b/hashicorp/instances/main.tf
@@ -14,7 +14,7 @@
 
 variable "aws_deploy_region" {
   type = string
-  description = "The EC2 region"
+  description = "The EC2 region injected through inversion of control"
 }
 
 variable "zone_id" {
@@ -49,7 +49,7 @@ data "aws_ami" "latest-astraios" {
 
   filter {
     name   = "name"
-    values = ["astraios"]
+    values = ["nexusgraph-astraios"]
   }
 
   filter {
@@ -60,7 +60,7 @@ data "aws_ami" "latest-astraios" {
 
 resource "aws_instance" "astraios" {
   ami = "${data.aws_ami.latest-astraios.id}"
-  instance_type = "t2.micro"
+  instance_type = "t2.small"
   tags = {
     Name = "Paion Data Astraios"
   }
@@ -74,4 +74,13 @@ resource "aws_instance" "astraios" {
     cd /home/ubuntu/jetty-base
     java -jar $JETTY_HOME/start.jar
   EOF
+}
+
+resource "aws_route53_record" "astraios" {
+  zone_id         = var.zone_id
+  name            = "astraios.nexusgraph.com"
+  type            = "A"
+  ttl             = 300
+  records         = [aws_instance.astraios.public_ip]
+  allow_overwrite = true
 }

--- a/hashicorp/scripts/setup.sh
+++ b/hashicorp/scripts/setup.sh
@@ -19,19 +19,11 @@ sudo apt update && sudo apt upgrade -y
 sudo apt install software-properties-common -y
 
 # Install JDK 17 - https://www.rosehosting.com/blog/how-to-install-java-17-lts-on-ubuntu-20-04/
-sudo apt update
-sudo apt install openjdk-17-jdk openjdk-17-jre
+sudo apt update -y
+sudo apt install openjdk-17-jdk -y
+export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
-# Install Maven
-sudo apt install maven -y
-
-# Package WAR
-git clone https://github.com/ORG/REPO.git
-cd REPO
-mvn clean package -Dmaven.test.skip
-cd ../
-
-# Install and configure Jetty (version 17) container
+# Install and configure Jetty (for JDK 17) container
 JETTY_VERSION=11.0.15
 wget https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/$JETTY_VERSION/jetty-home-$JETTY_VERSION.tar.gz
 tar -xzvf jetty-home-$JETTY_VERSION.tar.gz
@@ -39,6 +31,12 @@ rm jetty-home-$JETTY_VERSION.tar.gz
 export JETTY_HOME=/home/ubuntu/jetty-home-$JETTY_VERSION
 mkdir jetty-base
 cd jetty-base
-java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy
-mv /home/ubuntu/REPO/target/REPO-1.0-SNAPSHOT.war webapps/ROOT.war
+java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp,websocket
+mv /home/ubuntu/ROOT.war webapps/ROOT.war
 cd ../
+
+# Install Nginx and load SSL config
+sudo apt install -y nginx
+sudo mv /home/ubuntu/nginx-ssl.conf /etc/nginx/sites-enabled/default
+sudo mv /home/ubuntu/server.crt /etc/ssl/certs/server.crt
+sudo mv /home/ubuntu/server.key /etc/ssl/private/server.key


### PR DESCRIPTION
Changelog
---------

### Added

- Deploying an instance for serving [production Nexus Graph](https://github.com/paion-data/nexusgraph)
- Configured SSL for deployed instance

### Changed

- Delegate YML & MD linting to [external action](https://github.com/paion-data/github-actions-workflows)
- Lifted WAR packaging up to GitHub Action so that CI/CD logic becomes much easier to maintain

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [ ] Documentation