### PR TITLE
Enable checkstyle Javadoc check on class/interface and method

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -169,6 +169,17 @@
             <property name="tokens" value="ENUM_CONSTANT_DEF"/>
             <property name="severity" value="error"/>
         </module>
+        <module name="MissingJavadocMethod">
+            <property name="scope" value="anoninner"/>
+            <property name="allowMissingPropertyJavadoc" value="true"/>
+            <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF"/>
+            <property name="severity" value="error"/>
+        </module>
+        <module name="MissingJavadocType">
+            <property name="scope" value="anoninner"/>
+            <property name="tokens" value="INTERFACE_DEF, CLASS_DEF, ENUM_DEF, ANNOTATION_DEF"/>
+            <property name="severity" value="error"/>
+        </module>
         <module name="NonEmptyAtclauseDescription">
             <property name="javadocTokens" value="	PARAM_LITERAL, RETURN_LITERAL, THROWS_LITERAL, DEPRECATED_LITERAL"/>
             <property name="severity" value="error"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - DB_DRIVER=com.mysql.jdbc.Driver
       - DB_DIALECT=org.hibernate.dialect.MySQLDialect
       - DB_URL=jdbc:mysql://db/elide?serverTimezone=UTC
+      - OAUTH_ENABLED=true
+      - JWKS_URL=https://u4v5ne.logto.app/oidc/jwks
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,7 @@ services:
       - DB_DRIVER=com.mysql.jdbc.Driver
       - DB_DIALECT=org.hibernate.dialect.MySQLDialect
       - DB_URL=jdbc:mysql://db/elide?serverTimezone=UTC
-      - OAUTH_ENABLED=true
-      - JWKS_URL=https://u4v5ne.logto.app/oidc/jwks
+      - OAUTH_ENABLED=false
     depends_on:
       db:
         condition: service_healthy

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 6
+title: Configuration
+---
+
+The configurations in this page can be set from several sources in the following order:
+
+1. the [operating system's environment variables]; for instance, an environment variable can be set with
+   `export OAUTH_ENABLED="true"`
+2. the [Java system properties]; for example, a Java system property can be set using
+   `System.setProperty("OAUTH_ENABLED", "true")`
+3. a **.properties** file placed under CLASSPATH. This file can be put under `src/main/resources` source directory with
+   contents, for example, `OAUTH_ENABLED=true`
+
+Core Properties
+---------------
+
+:::note
+
+The following configurations can be placed in the properties file called **application.properties**
+
+:::
+
+- `MODEL_PACKAGE_NAME`: The fully qualified package name that contains a set of Elide JPA models
+
+OAuth 2
+-------
+
+:::note
+
+The following configurations can be placed in the properties file called **oauth.properties**
+
+:::
+
+- `OAUTH_ENABLED`: Whether or not to enable [OAuthFilter] container request filter.
+- `JWKS_URL`: (**Required if `OAUTH_ENABLED` is set to `true`**) A standard [JWKS] URL that, on GET, returns a json
+  object such as
+
+  ```json
+  {
+      "keys": [
+          {
+              "kty": "EC",
+              "use": "sig",
+              "kid": "eTERknhur9q8gisdaf_dfrqrgdfsg",
+              "alg": "ES384",
+              "crv": "P-384",
+              "x": "sdfrgHGYF...",
+              "y": "sdfuUIG&8..."
+          }
+      ]
+  }
+  ```
+
+(Elide) JPA DataStore
+---------------------
+
+:::note
+
+The following configurations can be placed in the properties file called **jpadatastore.properties**
+
+:::
+
+- `DB_USER`: Persistence DB username (needs have both Read and Write permissions).
+- `DB_PASSWORD`: The persistence DB user password.
+- `DB_URL`: The persistence DB URL, such as "jdbc:mysql://localhost/elide?serverTimezone=UTC".
+- `DB_DRIVER`: The SQL DB driver class name, such as "com.mysql.jdbc.Driver".
+- `DB_DIALECT`: The SQL DB dialect name, such as "org.hibernate.dialect.MySQLDialect".
+
+[Java system properties]: https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
+[JWKS]: https://datatracker.ietf.org/doc/html/rfc7517
+
+[OAuthFilter]: https://paion-data.github.io/astraios/apidocs/com/paiondata/astraios/web/filters/OAuthFilter.html
+[operating system's environment variables]: https://docs.oracle.com/javase/tutorial/essential/environment/env.html

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <version.jcip.annotations>1.0</version.jcip.annotations>
         <version.slf4j>2.0.7</version.slf4j>
         <version.logback>1.4.7</version.logback>
-        <version.owner>1.1.2</version.owner>
+        <version.owner>1.0.12</version.owner>
         <version.groovy>4.0.6</version.groovy>
 
         <version.maven.war.plugin>3.2.2</version.maven.war.plugin>
@@ -447,11 +447,6 @@
     </profiles>
 
     <repositories>
-        <repository>
-            <id>paion</id>
-            <name>Paion Data Official Release Repository</name>
-            <url>https://nexus.paion-data.dev/repository/maven-oss</url>
-        </repository>
         <repository>
             <id>${env.ASTRAIOS_MODEL_PACKAGE_REPO_ID}</id>
             <name>Astraios model pacakge JAR repository</name>

--- a/src/main/java/com/paiondata/astraios/application/ResourceConfig.java
+++ b/src/main/java/com/paiondata/astraios/application/ResourceConfig.java
@@ -25,6 +25,7 @@ import org.aeonbits.owner.ConfigFactory;
 import org.glassfish.hk2.api.ServiceLocator;
 
 import jakarta.inject.Inject;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.ApplicationPath;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
@@ -46,7 +47,7 @@ public class ResourceConfig extends org.glassfish.jersey.server.ResourceConfig {
      * @param injector  A standard HK2 service locator
      */
     @Inject
-    public ResourceConfig(final ServiceLocator injector) {
+    public ResourceConfig(@NotNull final ServiceLocator injector) {
         this(injector, new BinderFactory(), OAUTH_CONFIG.authEnabled());
     }
 
@@ -58,8 +59,8 @@ public class ResourceConfig extends org.glassfish.jersey.server.ResourceConfig {
      * @param oauthEnabled  Flag on whether or not to enable auth feature, mainly for differentiating dev/test and prod
      */
     private ResourceConfig(
-            final ServiceLocator injector,
-            final BinderFactory binderFactory,
+            @NotNull final ServiceLocator injector,
+            @NotNull final BinderFactory binderFactory,
             final boolean oauthEnabled
     ) {
         packages(ENDPOINT_PACKAGE);

--- a/src/main/java/com/paiondata/astraios/config/ApplicationConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/ApplicationConfig.java
@@ -17,6 +17,7 @@ package com.paiondata.astraios.config;
 
 import org.aeonbits.owner.Config;
 
+import jakarta.validation.constraints.NotNull;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
@@ -24,26 +25,32 @@ import net.jcip.annotations.ThreadSafe;
  * {@link ApplicationConfig} provides an interface for retrieving configuration values, allowing for implicit type
  * conversion, defaulting, and use of a runtime properties interface to override configured settings.
  * <p>
- * {@link ApplicationConfig} supports overriding between properties:
+ * {@link ApplicationConfig} tries to load the configurations from several sources in the following order:
  * <ol>
- *     <li> It will try to load the given property from the
- *          <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">operating system's
- *          environment variables</a>; if an environment variable with the same name is found, its value will be
- *          returned. For instance, an environment variable can be set with
- *          {@code export EXAMPLE_CONFIG_KEY_NAME="some-value"}
- *     <li> Otherwise, it will try to load the given property from the
- *          <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">Java system properties
- *          </a>; if such property is defined, the associated value is returned. For example, a Java system property can
- *          be set using {@code System.setProperty("EXAMPLE_CONFIG_KEY_NAME", "some-value")}
- *     <li> <b>The first resource defining the property will prevail.</b>
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
+ *          operating system's environment variables</a>; for instance, an environment variable can be set with
+ *          {@code export EXAMPLE_CONFIG_KEY_NAME="foo"}
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">
+ *          Java system properties</a>; for example, a Java system property can
+ *          be set using {@code System.setProperty("EXAMPLE_CONFIG_KEY_NAME", "foo")}
+ *     <li> a file named <b>oauth.properties</b> placed under CLASSPATH. This file can be put under
+ *          {@code src/main/resources} source directory with contents, for example, {@code EXAMPLE_CONFIG_KEY_NAME=foo}
  * </ol>
+ * Note that environment config has higher priority than Java system properties. Java system properties have higher
+ * priority than file based configuration.
  */
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"classpath:application.properties", "system:env", "system:properties"})
+@Config.Sources({"system:env", "system:properties", "classpath:application.properties"})
 public interface ApplicationConfig extends Config {
 
+    /**
+     * The fully qualified package name that contains a set of Elide JPA models.
+     *
+     * @return a standard package name under which each class is a JPA entity class
+     */
+    @NotNull
     @Key("MODEL_PACKAGE_NAME")
     String modelPackageName();
 }

--- a/src/main/java/com/paiondata/astraios/config/JpaDatastoreConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/JpaDatastoreConfig.java
@@ -17,45 +17,75 @@ package com.paiondata.astraios.config;
 
 import org.aeonbits.owner.Config;
 
+import jakarta.validation.constraints.NotNull;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
 /**
- * {@link JpaDatastoreConfig} provides an interface for retrieving configuration values, allowing for implicit type
- * conversion, defaulting, and use of a runtime properties interface to override configured settings.
+ * {@link JpaDatastoreConfig} is responsible for all configs related to Elide JPA middleware.
  * <p>
- * {@link JpaDatastoreConfig} supports overriding between properties:
+ * {@link JpaDatastoreConfig} tries to load the configurations from several sources in the following order:
  * <ol>
- *     <li> It will try to load the given property from the
- *          <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">operating system's
- *          environment variables</a>; if an environment variable with the same name is found, its value will be
- *          returned. For instance, an environment variable can be set with
- *          {@code export EXAMPLE_CONFIG_KEY_NAME="some-value"}
- *     <li> Otherwise, it will try to load the given property from the
- *          <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">Java system properties
- *          </a>; if such property is defined, the associated value is returned. For example, a Java system property can
- *          be set using {@code System.setProperty("EXAMPLE_CONFIG_KEY_NAME", "some-value")}
- *     <li> <b>The first resource defining the property will prevail.</b>
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
+ *          operating system's environment variables</a>; for instance, an environment variable can be set with
+ *          {@code export DB_USER="foo"}
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">
+ *          Java system properties</a>; for example, a Java system property can
+ *          be set using {@code System.setProperty("DB_USER", "foo")}
+ *     <li> a file named <b>jpadatastore.properties</b> placed under CLASSPATH. This file can be put under
+ *          {@code src/main/resources} source directory with contents, for example, {@code DB_USER=foo}
  * </ol>
+ * Note that environment config has higher priority than Java system properties. Java system properties have higher
+ * priority than file based configuration.
  */
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"classpath:jpadatastore.properties", "system:env", "system:properties"})
+@Config.Sources({"system:env", "system:properties", "classpath:jpadatastore.properties"})
 public interface JpaDatastoreConfig extends Config {
 
+    /**
+     * Persistence DB username (needs have both Read and Write permissions).
+     *
+     * @return a credential
+     */
+    @NotNull
     @Key("DB_USER")
     String dbUser();
 
+    /**
+     * The persistence DB user password.
+     *
+     * @return a credential
+     */
+    @NotNull
     @Key("DB_PASSWORD")
     String dbPassword();
 
+    /**
+     * The persistence DB URL, such as "jdbc:mysql://localhost/elide?serverTimezone=UTC".
+     *
+     * @return a JDBC connection URL
+     */
+    @NotNull
     @Key("DB_URL")
     String dbUrl();
 
+    /**
+     * The SQL DB driver class name, such as "com.mysql.jdbc.Driver".
+     *
+     * @return a DB config string
+     */
+    @NotNull
     @Key("DB_DRIVER")
     String dbDriver();
 
+    /**
+     * The SQL DB dialect name, such as "org.hibernate.dialect.MySQLDialect".
+     *
+     * @return a DB config string
+     */
+    @NotNull
     @Key("DB_DIALECT")
     String dbDialect();
 }

--- a/src/main/java/com/paiondata/astraios/config/OAuthConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/OAuthConfig.java
@@ -17,38 +17,68 @@ package com.paiondata.astraios.config;
 
 import org.aeonbits.owner.Config;
 
+import jakarta.validation.constraints.NotNull;
 import net.jcip.annotations.Immutable;
 import net.jcip.annotations.ThreadSafe;
 
 /**
- * {@link OAuthConfig} provides an interface for retrieving configuration values, allowing for implicit type
- * conversion, defaulting, and use of a runtime properties interface to override configured settings.
+ * {@link OAuthConfig} is responsible for all configs related to OAuth 2 aspects of the template.
  * <p>
- * {@link OAuthConfig} supports overriding between properties:
+ * {@link OAuthConfig} tries to load the configurations from several sources in the following order:
  * <ol>
- *     <li> It will try to load the given property from the
- *          <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">operating system's
- *          environment variables</a>; if an environment variable with the same name is found, its value will be
- *          returned. For instance, an environment variable can be set with
- *          {@code export EXAMPLE_CONFIG_KEY_NAME="some-value"}
- *     <li> Otherwise, it will try to load the given property from the
- *          <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">Java system properties
- *          </a>; if such property is defined, the associated value is returned. For example, a Java system property can
- *          be set using {@code System.setProperty("EXAMPLE_CONFIG_KEY_NAME", "some-value")}
- *     <li> <b>The first resource defining the property will prevail.</b>
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
+ *          operating system's environment variables</a>; for instance, an environment variable can be set with
+ *          {@code export OAUTH_ENABLED="true"}
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">
+ *          Java system properties</a>; for example, a Java system property can
+ *          be set using {@code System.setProperty("OAUTH_ENABLED", "true")}
+ *     <li> a file named <b>oauth.properties</b> placed under CLASSPATH. This file can be put under
+ *          {@code src/main/resources} source directory with contents, for example, {@code OAUTH_ENABLED=true}
  * </ol>
+ * Note that environment config has higher priority than Java system properties. Java system properties have higher
+ * priority than file based configuration.
  */
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"classpath:oauth.properties", "system:env", "system:properties"})
+@Config.Sources({"system:env", "system:properties", "classpath:oauth.properties"})
 public interface OAuthConfig extends Config {
 
+    /**
+     * Whether or not to enable {@link com.qubitpi.ws.jersey.template.web.filters.OAuthFilter} container request filter.
+     *
+     * @return {@code true} if enabling the OAuth filter or {@code false}, otherwise
+     */
+    @NotNull
     @Key("OAUTH_ENABLED")
-    @DefaultValue("false")
     boolean authEnabled();
 
+    /**
+     * A standard <a href="https://datatracker.ietf.org/doc/html/rfc7517">JWKS</a> URL that, on GET, returns a json
+     * object.
+     * <p>
+     * For example:
+     * <pre>
+     * {@code
+     * {
+     *     "keys": [
+     *         {
+     *             "kty": "EC",
+     *             "use": "sig",
+     *             "kid": "eTERknhur9q8gisdaf_dfrqrgdfsg",
+     *             "alg": "ES384",
+     *             "crv": "P-384",
+     *             "x": "sdfrgHGYF...",
+     *             "y": "sdfuUIG&8..."
+     *         }
+     *     ]
+     * }
+     * }
+     * </pre>
+     *
+     * @return a valid URL
+     */
+    @NotNull
     @Key("JWKS_URL")
-    @DefaultValue("https://u4v5ne.logto.app/oidc/jwks")
     String jwksUrl();
 }

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -20,6 +20,9 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 
+/**
+ * {@link CorsFilter} prevents corss-origin request error in local dev environment.
+ */
 public class CorsFilter implements ContainerResponseFilter {
 
     @Override

--- a/src/main/java/com/paiondata/astraios/web/filters/OAuthFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/OAuthFilter.java
@@ -31,6 +31,12 @@ import net.jcip.annotations.ThreadSafe;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * {@link OAuthFilter} is responsible for all OAuth 2 authorization logics, excluding authentications.
+ *
+ * For example, the filter validates an access token using an {@link AccessTokenValidator} that is
+ * <a href="https://stackoverflow.com/a/61620914">injected</a> into it.
+ */
 @Provider
 @Immutable
 @ThreadSafe

--- a/src/test/groovy/com/paiondata/astraios/application/AbstractITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/AbstractITSpec.groovy
@@ -24,6 +24,7 @@ import spock.lang.Specification
 class AbstractITSpec extends Specification {
 
     static final int WS_PORT = 8080
+    static final String VALID_TOKEN = "eyJhbGciOiJFUzM4NCIsInR5cCI6ImF0K2p3dCIsImtpZCI6IlR2WEQ5dkM3SU4tQ3IwRWhGWUlfemZselVMVXZEYnN0TTFuSWVibDJlNncifQ.eyJqdGkiOiJXZkNqX3Z0OWpjamNZcHBMMVVsOFEiLCJzdWIiOiJ2ajhqbXBzYnJjYjkiLCJpYXQiOjE2OTQwNzQyOTgsImV4cCI6Mzg0MTU1Nzk0NSwic2NvcGUiOiIiLCJjbGllbnRfaWQiOiJ5cG9uODl6OHJ0cmpkZzV0YTY2OWwiLCJpc3MiOiJodHRwczovL3U0djVuZS5sb2d0by5hcHAvb2lkYyIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC92MS9kYXRhIn0.NUpvIX1iHq06S0G3swreoc7ixBxQfcGfd8jvqmMeBbnUaTQJ-Ap-UYwJkiZ0ojuOjG2_gETG0HcNcrugo6VKNmyU0-woh2-eA9ROqNNOjkHC41hDOdnBCzB-2__Qo_Xd"
 
     def childSetupSpec() {
         // intentionally left blank
@@ -38,16 +39,18 @@ class AbstractITSpec extends Specification {
         RestAssured.port = WS_PORT
         RestAssured.basePath = "/v1/data/"
         RestAssured.requestSpecification = new RequestSpecBuilder()
-                .addHeader(
-                        OAuthFilter.AUTHORIZATION_HEADER,
-                        OAuthFilter.AUTHORIZATION_SCHEME + " " + "someAccessToken")
+                .addHeader(OAuthFilter.AUTHORIZATION_HEADER, OAuthFilter.AUTHORIZATION_SCHEME + " " + VALID_TOKEN)
                 .build()
+
+        System.setProperty("OAUTH_ENABLED", "true")
+        System.setProperty("JWKS_URL", "https://u4v5ne.logto.app/oidc/jwks")
 
         childSetupSpec()
     }
 
     def cleanupSpec() {
         RestAssured.reset()
+        System.clearProperty("OAUTH_ENABLED")
 
         childCleanupSpec()
     }

--- a/src/test/groovy/com/paiondata/astraios/application/AbstractITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/AbstractITSpec.groovy
@@ -38,19 +38,12 @@ class AbstractITSpec extends Specification {
         RestAssured.baseURI = "http://localhost"
         RestAssured.port = WS_PORT
         RestAssured.basePath = "/v1/data/"
-        RestAssured.requestSpecification = new RequestSpecBuilder()
-                .addHeader(OAuthFilter.AUTHORIZATION_HEADER, OAuthFilter.AUTHORIZATION_SCHEME + " " + VALID_TOKEN)
-                .build()
-
-        System.setProperty("OAUTH_ENABLED", "true")
-        System.setProperty("JWKS_URL", "https://u4v5ne.logto.app/oidc/jwks")
 
         childSetupSpec()
     }
 
     def cleanupSpec() {
         RestAssured.reset()
-        System.clearProperty("OAUTH_ENABLED")
 
         childCleanupSpec()
     }

--- a/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
@@ -32,13 +32,18 @@ class DockerComposeITSpec extends AbstractITSpec {
             .withExposedService(
                     "web",
                     WS_PORT,
-                    Wait.forHttp("/v1/data/note")
-                            .withHeader(
-                                    OAuthFilter.AUTHORIZATION_HEADER,
-                                    OAuthFilter.AUTHORIZATION_SCHEME + " " + VALID_TOKEN
-                            )
-                            .forStatusCode(200)
+                    Wait.forHttp("/v1/data/note").forStatusCode(200)
             )
+
+    @Override
+    def childSetupSpec() {
+        System.setProperty("OAUTH_ENABLED", "false")
+    }
+
+    @Override
+    def childCleanupSpec() {
+        System.clearProperty("OAUTH_ENABLED")
+    }
 
     def "JSON API allows for POSTing and GETing an entity"() {
         expect: "database is initially empty"

--- a/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
@@ -15,6 +15,8 @@
  */
 package com.paiondata.astraios.application
 
+import com.paiondata.astraios.web.filters.OAuthFilter
+
 import org.hamcrest.Matchers
 import org.testcontainers.containers.DockerComposeContainer
 import org.testcontainers.containers.wait.strategy.Wait
@@ -31,7 +33,10 @@ class DockerComposeITSpec extends AbstractITSpec {
                     "web",
                     WS_PORT,
                     Wait.forHttp("/v1/data/note")
-                            .withHeader("Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                            .withHeader(
+                                    OAuthFilter.AUTHORIZATION_HEADER,
+                                    OAuthFilter.AUTHORIZATION_SCHEME + " " + VALID_TOKEN
+                            )
                             .forStatusCode(200)
             )
 

--- a/src/test/groovy/com/paiondata/astraios/application/ResourceConfigITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/ResourceConfigITSpec.groovy
@@ -17,6 +17,8 @@ package com.paiondata.astraios.application
 
 import com.yahoo.elide.jsonapi.JsonApi
 
+import com.paiondata.astraios.web.filters.OAuthFilter
+
 import org.apache.http.HttpStatus
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
@@ -27,6 +29,7 @@ import org.testcontainers.containers.MySQLContainer
 import org.testcontainers.spock.Testcontainers
 
 import io.restassured.RestAssured
+import io.restassured.builder.RequestSpecBuilder
 import spock.lang.Shared
 
 @Testcontainers
@@ -41,10 +44,23 @@ class ResourceConfigITSpec extends AbstractITSpec {
 
     @Override
     def childSetupSpec() {
+        RestAssured.requestSpecification = new RequestSpecBuilder()
+                .addHeader(OAuthFilter.AUTHORIZATION_HEADER, OAuthFilter.AUTHORIZATION_SCHEME + " " + VALID_TOKEN)
+                .build()
+
+        System.setProperty("OAUTH_ENABLED", "true")
+        System.setProperty("JWKS_URL", "https://u4v5ne.logto.app/oidc/jwks")
+
         System.setProperty(
                 "DB_URL",
                 String.format("jdbc:mysql://localhost:%s/elide?serverTimezone=UTC", MYSQL.firstMappedPort)
         )
+    }
+
+    @Override
+    def childCleanupSpec() {
+        System.clearProperty("OAUTH_ENABLED")
+        System.clearProperty("JWKS_URL")
     }
 
     @SuppressWarnings('GroovyAccessibility')

--- a/src/test/groovy/com/paiondata/astraios/application/ResourceConfigSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/ResourceConfigSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright Jiaqi Liu
+ * Copyright Paion Data
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import spock.lang.Unroll
 
 class ResourceConfigSpec extends Specification {
 
-    static final OAuthConfig OAUTH_CONFIG = ConfigFactory.create(OAuthConfig.class)
     static final Set<Class> ALWAYS_REGISTERED_FILTERS = [CorsFilter, JsonApiEndpoint] as Set
 
     @SuppressWarnings('GroovyAccessibility')
@@ -43,7 +42,7 @@ class ResourceConfigSpec extends Specification {
         org.glassfish.jersey.server.ResourceConfig resourceConfig = new ResourceConfig(
                 Mock(ServiceLocator),
                 binderFactory,
-                OAUTH_CONFIG.authEnabled()
+                false
         )
 
         then: "all request & response filters are injected"

--- a/src/test/groovy/com/paiondata/astraios/web/filters/oauth/ES384JwtTokenValidatorSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/web/filters/oauth/ES384JwtTokenValidatorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright Jiaqi Liu
+ * Copyright Paion Data
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import com.auth0.jwk.Jwk
 import com.auth0.jwk.JwkException
 import com.auth0.jwk.JwkProvider
 import com.auth0.jwt.exceptions.SignatureVerificationException
+import com.paiondata.astraios.application.AbstractITSpec
 
 import spock.lang.Specification
 
@@ -95,7 +96,7 @@ class ES384JwtTokenValidatorSpec extends Specification {
      * @return a valid ES384 token that can be verified by keys from "https://u4v5ne.logto.app/oidc/jwks"
      */
     String validToken() {
-        "eyJhbGciOiJFUzM4NCIsInR5cCI6ImF0K2p3dCIsImtpZCI6IlR2WEQ5dkM3SU4tQ3IwRWhGWUlfemZselVMVXZEYnN0TTFuSWVibDJlNncifQ.eyJqdGkiOiJXZkNqX3Z0OWpjamNZcHBMMVVsOFEiLCJzdWIiOiJ2ajhqbXBzYnJjYjkiLCJpYXQiOjE2OTQwNzQyOTgsImV4cCI6Mzg0MTU1Nzk0NSwic2NvcGUiOiIiLCJjbGllbnRfaWQiOiJ5cG9uODl6OHJ0cmpkZzV0YTY2OWwiLCJpc3MiOiJodHRwczovL3U0djVuZS5sb2d0by5hcHAvb2lkYyIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC92MS9kYXRhIn0.NUpvIX1iHq06S0G3swreoc7ixBxQfcGfd8jvqmMeBbnUaTQJ-Ap-UYwJkiZ0ojuOjG2_gETG0HcNcrugo6VKNmyU0-woh2-eA9ROqNNOjkHC41hDOdnBCzB-2__Qo_Xd"
+        AbstractITSpec.VALID_TOKEN
     }
 
     String invalidToken() {

--- a/src/test/java/com/paiondata/astraios/models/Book.java
+++ b/src/test/java/com/paiondata/astraios/models/Book.java
@@ -21,6 +21,9 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
+/**
+ * A test entity.
+ */
 @Entity
 @Table(name = "Book")
 @Include(rootLevel = true, name = "book", description = "book entity", friendlyName = "book")


### PR DESCRIPTION
Changelog
---------

### Added

- Added documentation on all WS configurations

### Changed

- Bumped OWNER config version so that it can [pick up OS and JVM properties](https://matteobaccan.github.io/owner/docs/importing-properties/):

<img width="708" alt="page" src="https://github.com/QubitPi/jersey-ws-template/assets/16126939/be633952-4ce0-4d0a-913d-27849eba0980">

### Deprecated

### Removed

### Fixed

- Added checkstyle rules that detects missing Javadoc on class/interface & method
- Only bind token validator if OAuth is turned on

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
