### PR TITLE
Remove websocket Jetty module from deployment

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -21,7 +21,7 @@ The following configurations can be placed in the properties file called **appli
 
 :::
 
-- `MODEL_PACKAGE_NAME`: The fully qualified package name that contains a set of Elide JPA models
+- **MODEL_PACKAGE_NAME**: The fully qualified package name that contains a set of Elide JPA models
 
 OAuth 2
 -------
@@ -32,8 +32,8 @@ The following configurations can be placed in the properties file called **oauth
 
 :::
 
-- `OAUTH_ENABLED`: Whether or not to enable [OAuthFilter] container request filter.
-- `JWKS_URL`: (**Required if `OAUTH_ENABLED` is set to `true`**) A standard [JWKS] URL that, on GET, returns a json
+- **OAUTH_ENABLED**: Whether or not to enable [OAuthFilter] container request filter.
+- **JWKS_URL**: (**Required if `OAUTH_ENABLED` is set to `true`**) A standard [JWKS] URL that, on GET, returns a json
   object such as
 
   ```json
@@ -61,11 +61,11 @@ The following configurations can be placed in the properties file called **jpada
 
 :::
 
-- `DB_USER`: Persistence DB username (needs have both Read and Write permissions).
-- `DB_PASSWORD`: The persistence DB user password.
-- `DB_URL`: The persistence DB URL, such as "jdbc:mysql://localhost/elide?serverTimezone=UTC".
-- `DB_DRIVER`: The SQL DB driver class name, such as "com.mysql.jdbc.Driver".
-- `DB_DIALECT`: The SQL DB dialect name, such as "org.hibernate.dialect.MySQLDialect".
+- **DB_USER**: Persistence DB username (needs have both Read and Write permissions).
+- **DB_PASSWORD**: The persistence DB user password.
+- **DB_URL**: The persistence DB URL, such as "jdbc:mysql://localhost/elide?serverTimezone=UTC".
+- **DB_DRIVER**: The SQL DB driver class name, such as "com.mysql.jdbc.Driver".
+- **DB_DIALECT**: The SQL DB dialect name, such as "org.hibernate.dialect.MySQLDialect".
 
 [Java system properties]: https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html
 [JWKS]: https://datatracker.ietf.org/doc/html/rfc7517

--- a/hashicorp/scripts/setup.sh
+++ b/hashicorp/scripts/setup.sh
@@ -31,7 +31,7 @@ rm jetty-home-$JETTY_VERSION.tar.gz
 export JETTY_HOME=/home/ubuntu/jetty-home-$JETTY_VERSION
 mkdir jetty-base
 cd jetty-base
-java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp,websocket
+java -jar $JETTY_HOME/start.jar --add-module=annotations,server,http,deploy,servlet,webapp,resources,jsp
 mv /home/ubuntu/ROOT.war webapps/ROOT.war
 cd ../
 

--- a/src/main/java/com/paiondata/astraios/application/ResourceConfig.java
+++ b/src/main/java/com/paiondata/astraios/application/ResourceConfig.java
@@ -81,9 +81,7 @@ public class ResourceConfig extends org.glassfish.jersey.server.ResourceConfig {
         register(new org.glassfish.hk2.utilities.binding.AbstractBinder() {
             @Override
             protected void configure() {
-                final Elide elide = injector.getService(Elide.class, "elide");
-
-                elide.doScans();
+                injector.getService(Elide.class, "elide").doScans();
             }
         });
     }

--- a/src/test/groovy/com/paiondata/astraios/application/AbstractITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/AbstractITSpec.groovy
@@ -15,10 +15,7 @@
  */
 package com.paiondata.astraios.application
 
-import com.paiondata.astraios.web.filters.OAuthFilter
-
 import io.restassured.RestAssured
-import io.restassured.builder.RequestSpecBuilder
 import spock.lang.Specification
 
 class AbstractITSpec extends Specification {

--- a/src/test/groovy/com/paiondata/astraios/application/ResourceConfigITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/ResourceConfigITSpec.groovy
@@ -59,8 +59,9 @@ class ResourceConfigITSpec extends AbstractITSpec {
 
     @Override
     def childCleanupSpec() {
-        System.clearProperty("OAUTH_ENABLED")
+        System.clearProperty("DB_URL")
         System.clearProperty("JWKS_URL")
+        System.clearProperty("OAUTH_ENABLED")
     }
 
 

--- a/src/test/groovy/com/paiondata/astraios/application/ResourceConfigSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/ResourceConfigSpec.groovy
@@ -17,11 +17,9 @@ package com.paiondata.astraios.application
 
 import com.yahoo.elide.jsonapi.resources.JsonApiEndpoint
 
-import com.paiondata.astraios.config.OAuthConfig
 import com.paiondata.astraios.web.filters.CorsFilter
 import com.paiondata.astraios.web.filters.OAuthFilter
 
-import org.aeonbits.owner.ConfigFactory
 import org.glassfish.hk2.api.ServiceLocator
 import org.glassfish.jersey.internal.inject.Binder
 


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Although [GraphQL endpoint is working](https://github.com/paion-data/astraios/pull/22), the deployment still has `websocket` module enabled in Jetty. [This PR removed it](https://github.com/paion-data/astraios/pull/24/files#diff-92052ad1c61a5571dedb9c7ed0362be8572d23d3a795d48335369f91f687b2f8L34)
- Minor documentation enhancements

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
