### PR TITLE
Fix broken links in documentation

### DIFF
--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -172,15 +172,6 @@ To optionally disable GraphQL endpoints, exclude corresponding dependencies in P
         </dependency>
 ```
 
-[Astraios]: https://paion-data.github.io/astraios/
-
-[Elide]: https://elide.io/
-[Elide instance class]: https://github.com/yahoo/elide/blob/master/elide-core/src/main/java/com/yahoo/elide/Elide.java
-[Elide Standalone]: https://github.com/yahoo/elide/tree/master/elide-standalone
-[ElideSettings instance class]: https://github.com/yahoo/elide/blob/master/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
-
-[what is binding]: https://qubitpi.github.io/jersey/ioc.html
-
 Running Webservice in Standalone Jetty (Production)
 ---------------------------------------------------
 

--- a/docs/docs/elide.md
+++ b/docs/docs/elide.md
@@ -23,3 +23,12 @@ otherwise, dependency injection will flaky and not right.
 :::
 
 ![Error loading resource-binding.png](./img/resource-binding.png)
+
+[Astraios]: https://paion-data.github.io/astraios/
+
+[Elide]: https://elide.io/
+[Elide instance class]: https://github.com/yahoo/elide/blob/master/elide-core/src/main/java/com/yahoo/elide/Elide.java
+[Elide Standalone]: https://github.com/yahoo/elide/tree/master/elide-standalone
+[ElideSettings instance class]: https://github.com/yahoo/elide/blob/master/elide-core/src/main/java/com/yahoo/elide/ElideSettings.java
+
+[what is binding]: https://qubitpi.github.io/jersey/ioc.html


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

### Deprecated

### Removed


### Fixed

- Fixed following broken links in [Elide doc page](https://paion-data.github.io/astraios/docs/elide)

  <img width="1024" alt="page 1" src="https://github.com/paion-data/astraios/assets/16126939/422003db-606b-47bb-a452-a853f48075c2">

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation
