### PR TITLE
Send Astraios logs to ELK

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -145,6 +145,9 @@ jobs:
         run: |
           echo '${{ secrets.SSL_CERTIFICATE }}' > server.crt
           echo '${{ secrets.SSL_CERTIFICATE_KEY }}' > server.key
+      - name: Inject Logstash host into Filebeat config file
+        working-directory: hashicorp/images
+        run: sed -i -e 's,logstash-host,'elk.nexusgraph.com',g' filebeat.yml
       - name: Load runtime settings into Terraform variable file
         working-directory: hashicorp/instances
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -135,8 +135,8 @@ jobs:
           astraios-model-package-repo-url: ${{ secrets.ASTRAIOS_MODEL_PACKAGE_REPO_URL }}
       - name: Load webservice settings
         run: |
-          echo "${{ secrets.APPLICATION_PROPERTIES }}" > src/main/resources/application.properties
           echo "${{ secrets.OAUTH_PROPERTIES }}" > src/main/resources/oauth.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES }}" > src/main/resources/application.properties
           echo "${{ secrets.JPADATASTORE_PROPERTIES }}" > src/main/resources/jpadatastore.properties
       - name: Generate webservice WAR file
         run: mvn -B clean package
@@ -147,7 +147,7 @@ jobs:
           echo '${{ secrets.SSL_CERTIFICATE_KEY }}' > server.key
       - name: Inject Logstash host into Filebeat config file
         working-directory: hashicorp/images
-        run: sed -i -e 's,logstash-host,'elk.nexusgraph.com',g' filebeat.yml
+        run: sed -i -e 's,logstash-host,'${{ secrets.ELK_URL }}',g' filebeat.yml
       - name: Load runtime settings into Terraform variable file
         working-directory: hashicorp/instances
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,67 @@
 .idea/
 target/
 .DS_Store
+
+# Created by https://www.toptal.com/developers/gitignore/api/packer,terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=packer,terraform
+
+### Packer ###
+# Cache objects
+packer_cache/
+
+# Crash log
+crash.log
+
+# https://www.packer.io/guides/hcl/variables
+# Exclude all .pkrvars.hcl files, which are likely to contain sensitive data,
+# such as password, private keys, and other secrets. These should not be part of
+# version control as they are data points which are potentially sensitive and
+# subject to change depending on the environment.
+#
+*.pkrvars.hcl
+
+# For built boxes
+*.box
+
+### Packer Patch ###
+# ignore temporary output files
+output-*/
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+.terraform.lock.hcl
+
+# End of https://www.toptal.com/developers/gitignore/api/packer,terraform

--- a/hashicorp/images/filebeat.yml
+++ b/hashicorp/images/filebeat.yml
@@ -19,7 +19,7 @@ filebeat.config.modules:
 filebeat.inputs:
   - type: log
     paths:
-      - /home/ubuntu/logstash-tutorial.log
+      - /home/ubuntu/jetty-base/logback/astraios.log
 
 output.logstash:
   hosts: ["logstash-host:5044"]

--- a/hashicorp/images/filebeat.yml
+++ b/hashicorp/images/filebeat.yml
@@ -1,0 +1,25 @@
+# Copyright Paion Data
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+filebeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
+
+filebeat.inputs:
+  - type: log
+    paths:
+      - /home/ubuntu/logstash-tutorial.log
+
+output.logstash:
+  hosts: ["logstash-host:5044"]

--- a/hashicorp/images/nexusgraph-astraios.pkr.hcl
+++ b/hashicorp/images/nexusgraph-astraios.pkr.hcl
@@ -68,6 +68,12 @@ build {
     destination = "/home/ubuntu/ROOT.war"
   }
 
+  # Load Filebeat config into AMI image
+  provisioner "file" {
+    source = "./filebeat.yml"
+    destination = "/home/ubuntu/filebeat.yml"
+  }
+
   provisioner "shell" {
     script = "../scripts/setup.sh"
   }

--- a/hashicorp/instances/main.tf
+++ b/hashicorp/instances/main.tf
@@ -71,6 +71,8 @@ resource "aws_instance" "astraios" {
     export JETTY_HOME=/home/ubuntu/jetty-home-11.0.15
     export SENTRY_DSN=${var.sentry_dsn}
 
+    sudo /usr/bin/filebeat -e -c filebeat.yml -d "publish" &
+
     cd /home/ubuntu/jetty-base
     java -jar $JETTY_HOME/start.jar
   EOF

--- a/hashicorp/instances/main.tf
+++ b/hashicorp/instances/main.tf
@@ -64,6 +64,7 @@ resource "aws_instance" "astraios" {
   tags = {
     Name = "Paion Data Astraios"
   }
+
   security_groups = ["Paion Data Astraios"]
 
   user_data = <<-EOF

--- a/hashicorp/scripts/setup.sh
+++ b/hashicorp/scripts/setup.sh
@@ -40,3 +40,8 @@ sudo apt install -y nginx
 sudo mv /home/ubuntu/nginx-ssl.conf /etc/nginx/sites-enabled/default
 sudo mv /home/ubuntu/server.crt /etc/ssl/certs/server.crt
 sudo mv /home/ubuntu/server.key /etc/ssl/private/server.key
+
+# Install Filebeat for sending logs to ELK
+curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.9.2-amd64.deb
+sudo dpkg -i filebeat-8.9.2-amd64.deb
+sudo mv /home/ubuntu/filebeat.yml /etc/filebeat/filebeat.yml

--- a/hashicorp/scripts/setup.sh
+++ b/hashicorp/scripts/setup.sh
@@ -41,7 +41,8 @@ sudo mv /home/ubuntu/nginx-ssl.conf /etc/nginx/sites-enabled/default
 sudo mv /home/ubuntu/server.crt /etc/ssl/certs/server.crt
 sudo mv /home/ubuntu/server.key /etc/ssl/private/server.key
 
-# Install Filebeat for sending logs to ELK
+# Filebeat
 curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.9.2-amd64.deb
 sudo dpkg -i filebeat-8.9.2-amd64.deb
 sudo mv /home/ubuntu/filebeat.yml /etc/filebeat/filebeat.yml
+sudo chown root /etc/filebeat/filebeat.yml

--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
             <version>${version.logback}</version>
         </dependency>
         <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>4.11</version>
+        </dependency>
+        <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
             <version>6.25.2</version>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,17 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <configuration>
-    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
+    <appender name="ELK" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logback/astraios.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logback/astraios.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
     </appender>
 
     <appender name="Sentry" class="io.sentry.logback.SentryAppender">
     </appender>
 
     <root level="INFO">
-        <appender-ref ref="Console" />
+        <appender-ref ref="ELK" />
         <appender-ref ref="Sentry" />
     </root>
 </configuration>


### PR DESCRIPTION
Changelog
---------

### Added

- Enabled Astraios to send webservice logs to a specified ELK in order to achieve the monitoring of Astraios' _immutable infrastructure_ design

### Changed

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [x] Documentation

Reference
---------

- [Parsing Logs with Logstash](https://qubitpi.github.io/logstash/advanced-pipeline.html#indexing-parsed-data-into-elasticsearch)
- [Packer - Assigning Variables](https://developer.hashicorp.com/packer/guides/hcl/variables)
- [Search & Replace String Value in YAML with format using Shell](https://stackoverflow.com/a/54614058)
- [Send the Logs of a Java App to ELK](https://www.baeldung.com/java-application-logs-to-elastic-stack)