### PR TITLE
Add preflight request filter

### DIFF
--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -40,6 +40,10 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
             @NotNull final ContainerRequestContext request,
             @NotNull final ContainerResponseContext response
     ) {
+        if (request.getHeaderString("Origin") == null) {
+            return;
+        }
+
         response.getHeaders().add("Access-Control-Allow-Origin", "*");
         response.getHeaders().add(
                 "Access-Control-Allow-Headers",

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.core.Response;
  */
 public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
-    static final String originHeader = "Origin";
+    static final String ORIGIN_HEADER = "Origin";
 
     @Override
     public void filter(@NotNull final ContainerRequestContext request) {
@@ -42,7 +42,7 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
             @NotNull final ContainerRequestContext request,
             @NotNull final ContainerResponseContext response
     ) {
-        if (request.getHeaderString(originHeader) == null) {
+        if (request.getHeaderString(ORIGIN_HEADER) == null) {
             return;
         }
 
@@ -73,7 +73,7 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
      * @return {@code true} if the request is a preflight request or {@code false}, otherwise
      */
     private static boolean isPreflightRequest(@NotNull final ContainerRequestContext request) {
-        return request.getHeaderString(originHeader) != null
+        return request.getHeaderString(ORIGIN_HEADER) != null
                 && request.getMethod().equalsIgnoreCase("OPTIONS");
     }
 }

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -28,7 +28,9 @@ import jakarta.ws.rs.core.Response;
 public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
     @Override
-    public void filter(ContainerRequestContext request)  {
+    public void filter(
+            @NotNull final ContainerRequestContext request
+    ) {
         if (isPreflightRequest(request)) {
             request.abortWith(Response.ok().build());
         }
@@ -36,6 +38,10 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 
     /**
      * A preflight request is an OPTIONS request with an Origin header.
+     *
+     * @param request  A preflight request
+     *
+     * @return A judgment result of the boolean type
      */
     private static boolean isPreflightRequest(
             @NotNull final ContainerRequestContext request

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -34,7 +34,12 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
         }
     }
 
-    private static boolean isPreflightRequest(ContainerRequestContext request) {
+    /**
+     * A preflight request is an OPTIONS request with an Origin header.
+     */
+    private static boolean isPreflightRequest(
+            @NotNull final ContainerRequestContext request
+    ) {
         return request.getHeaderString("Origin") != null
                 && request.getMethod().equalsIgnoreCase("OPTIONS");
     }

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -28,6 +28,8 @@ import jakarta.ws.rs.core.Response;
  */
 public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
+    final static String originHeader = "Origin";
+
     @Override
     public void filter(@NotNull final ContainerRequestContext request) {
         if (isPreflightRequest(request)) {
@@ -40,7 +42,7 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
             @NotNull final ContainerRequestContext request,
             @NotNull final ContainerResponseContext response
     ) {
-        if (request.getHeaderString("Origin") == null) {
+        if (request.getHeaderString(originHeader) == null) {
             return;
         }
 
@@ -71,7 +73,7 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
      * @return {@code true} if the request is a preflight request or {@code false}, otherwise
      */
     private static boolean isPreflightRequest(@NotNull final ContainerRequestContext request) {
-        return request.getHeaderString("Origin") != null
+        return request.getHeaderString(originHeader) != null
                 && request.getMethod().equalsIgnoreCase("OPTIONS");
     }
 }

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -24,7 +24,7 @@ import jakarta.ws.rs.core.Response;
 
 /**
  * {@link CorsFilter} prevents corss-origin request error in local dev environment, and abort the preflight request and
- * make the request successful
+ * make the request successful.
  */
 public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -17,13 +17,27 @@ package com.paiondata.astraios.web.filters;
 
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
 import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.core.Response;
 
 /**
  * {@link CorsFilter} prevents corss-origin request error in local dev environment.
  */
-public class CorsFilter implements ContainerResponseFilter {
+public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext request)  {
+        if (isPreflightRequest(request)) {
+            request.abortWith(Response.ok().build());
+        }
+    }
+
+    private static boolean isPreflightRequest(ContainerRequestContext request) {
+        return request.getHeaderString("Origin") != null
+                && request.getMethod().equalsIgnoreCase("OPTIONS");
+    }
 
     @Override
     public void filter(

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -28,7 +28,7 @@ import jakarta.ws.rs.core.Response;
  */
 public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
-    final static String originHeader = "Origin";
+    static final String originHeader = "Origin";
 
     @Override
     public void filter(@NotNull final ContainerRequestContext request) {

--- a/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
+++ b/src/main/java/com/paiondata/astraios/web/filters/CorsFilter.java
@@ -23,31 +23,16 @@ import jakarta.ws.rs.container.ContainerResponseFilter;
 import jakarta.ws.rs.core.Response;
 
 /**
- * {@link CorsFilter} prevents corss-origin request error in local dev environment.
+ * {@link CorsFilter} prevents corss-origin request error in local dev environment, and abort the preflight request and
+ * make the request successful
  */
 public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
     @Override
-    public void filter(
-            @NotNull final ContainerRequestContext request
-    ) {
+    public void filter(@NotNull final ContainerRequestContext request) {
         if (isPreflightRequest(request)) {
             request.abortWith(Response.ok().build());
         }
-    }
-
-    /**
-     * A preflight request is an OPTIONS request with an Origin header.
-     *
-     * @param request  A preflight request
-     *
-     * @return A judgment result of the boolean type
-     */
-    private static boolean isPreflightRequest(
-            @NotNull final ContainerRequestContext request
-    ) {
-        return request.getHeaderString("Origin") != null
-                && request.getMethod().equalsIgnoreCase("OPTIONS");
     }
 
     @Override
@@ -65,5 +50,24 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
                 "Access-Control-Allow-Methods",
                 "GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD"
         );
+    }
+
+    /**
+     * Returns whether or not a request is a preflight request.
+     * <p>
+     * A request is considered preflight if
+     * <ul>
+     *     <li> the request contains
+     *          <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin">"Origin"</a> header, and
+     *     <li> the request method is "OPTIONS"
+     * </ul>
+     *
+     * @param request  a pre-checked HTTP request
+     *
+     * @return {@code true} if the request is a preflight request or {@code false}, otherwise
+     */
+    private static boolean isPreflightRequest(@NotNull final ContainerRequestContext request) {
+        return request.getHeaderString("Origin") != null
+                && request.getMethod().equalsIgnoreCase("OPTIONS");
     }
 }

--- a/src/test/groovy/com/paiondata/astraios/application/ResourceConfigITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/ResourceConfigITSpec.groovy
@@ -246,7 +246,7 @@ class ResourceConfigITSpec extends AbstractITSpec {
                 ))
 
         when: "an entity is POSTed via GraphQL"
-        Response response =  createNewBook(new Book(title: "Book Numero Dos"))
+        Response response = createNewBook(new Book(title: "Book Numero Dos"))
         response.then()
                 .statusCode(200)
 

--- a/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
@@ -59,9 +59,11 @@ class CorsFilterSpec extends Specification {
         where:
         requestHeader  | requestMethod || callTimes
         "*"            |   "OPTIONS"   || 1
+        "*"            |     "POST"    || 0
+        null           |   "OPTIONS"   || 0
         null           |     "POST"    || 0
 
-        requestType = callTimes == 1 ? "Preflight request" : "Other requests"
+        requestType = callTimes == 1 ? "Preflight request" : "Other requests or no header"
         abort = callTimes == 1 ? "abort" : "not abort"
     }
 
@@ -79,6 +81,8 @@ class CorsFilterSpec extends Specification {
         where:
         requestHeader  | requestMethod || result
         "*"            |   "OPTIONS"   || true
+        "*"            |     "POST"    || false
+        null           |   "OPTIONS"   || false
         null           |     "POST"    || false
 
         judgment = result ? "is" : "not"

--- a/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
@@ -26,7 +26,7 @@ import spock.lang.Unroll
 class CorsFilterSpec extends Specification {
 
     @Unroll
-    def "Cross-origin header gets attached"() {
+    def "Cross-origin header #attached when #whetherOriginHeader"() {
         given:
         ContainerResponseContext response = Mock(ContainerResponseContext)
         MultivaluedMap headers = Mock(MultivaluedMap)
@@ -49,6 +49,9 @@ class CorsFilterSpec extends Specification {
         originHeader || callTimes
         "*"          || 1
         null         || 0
+
+        whetherOriginHeader = callTimes == 1 ? 'requests with "Origin" headers' : 'requests without "Origin" headers'
+        sttached = callTimes == 1 ? "gets attached" : "not gets attached"
     }
 
     @Unroll

--- a/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
@@ -25,10 +25,13 @@ import spock.lang.Unroll
 
 class CorsFilterSpec extends Specification {
 
+    @Unroll
     def "Cross-origin header gets attached"() {
         given:
         ContainerResponseContext response = Mock(ContainerResponseContext)
         MultivaluedMap headers = Mock(MultivaluedMap)
+        ContainerRequestContext request = Mock(ContainerRequestContext)
+        request.getHeaderString("Origin") >> originHeader
         response.getHeaders() >>> [
                 headers,
                 new MultivaluedHashMap<>([:]),
@@ -37,10 +40,15 @@ class CorsFilterSpec extends Specification {
         ]
 
         when:
-        new CorsFilter().filter(Mock(ContainerRequestContext), response)
+        new CorsFilter().filter(request, response)
 
         then:
-        1 * headers.add("Access-Control-Allow-Origin", "*")
+        callTimes * headers.add("Access-Control-Allow-Origin", "*")
+
+        where:
+        originHeader || callTimes
+        "*"          || 1
+        null         || 0
     }
 
     @Unroll

--- a/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
@@ -43,11 +43,12 @@ class CorsFilterSpec extends Specification {
         1 * headers.add("Access-Control-Allow-Origin", "*")
     }
 
+    @Unroll
     def "#requestType was #abort"() {
         given:
         ContainerRequestContext request = Mock(ContainerRequestContext)
         request.getHeaderString("Origin") >> requestHeader
-        request.getMethod() >>  requestMethod
+        request.getMethod() >> requestMethod
 
         when:
         new CorsFilter().filter(request)
@@ -56,15 +57,16 @@ class CorsFilterSpec extends Specification {
         callTimes * request.abortWith(_ as Response)
 
         where:
-        requestHeader  || requestMethod || callTimes
-        "*"            ||   "OPTIONS"   || 1
-        null           ||     "POST"    || 0
+        requestHeader  | requestMethod || callTimes
+        "*"            |   "OPTIONS"   || 1
+        null           |     "POST"    || 0
 
         requestType = callTimes == 1 ? "Preflight request" : "Other requests"
         abort = callTimes == 1 ? "abort" : "not abort"
     }
 
     @Unroll
+    @SuppressWarnings('GroovyAccessibility')
     def "The request #judgment a flight request"() {
         given:
         ContainerRequestContext request = Mock(ContainerRequestContext)
@@ -75,9 +77,9 @@ class CorsFilterSpec extends Specification {
         CorsFilter.isPreflightRequest(request) == result
 
         where:
-        requestHeader  || requestMethod || result
-        "*"            ||   "OPTIONS"   || true
-        null           ||     "POST"    || false
+        requestHeader  | requestMethod || result
+        "*"            |   "OPTIONS"   || true
+        null           |     "POST"    || false
 
         judgment = result ? "is" : "not"
     }

--- a/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/web/filters/CorsFilterSpec.groovy
@@ -51,7 +51,7 @@ class CorsFilterSpec extends Specification {
         null         || 0
 
         whetherOriginHeader = callTimes == 1 ? 'requests with "Origin" headers' : 'requests without "Origin" headers'
-        sttached = callTimes == 1 ? "gets attached" : "not gets attached"
+        attached = callTimes == 1 ? "gets attached" : "not gets attached"
     }
 
     @Unroll


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Avoid preflight request, which does not contain token header, from being validated by the OAuthFilter by adding a pre-preflight request check in CORS filter

  - If the request is a preflight, it will be bounced back immediately with a `200`

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [ ] Self-review
- [ ] Documentation
