### PR TITLE
Reverse config loading order

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -39,10 +39,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Environment setup
-        uses: ./.github/actions/setup
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          runbooks-repo-token: ${{ secrets.RUNBOOKS_REPO_TOKEN }}
+          java-version: '17'
+          distribution: 'adopt'
       - name: Set up Docker for Integration Tests
         uses: docker-practice/actions-setup-docker@master
       - name: Run unit & integration tests

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'adopt'
+      - name: Checkout HashiCorp deployment config files
+        run: git clone https://${{ secrets.RUNBOOKS_REPO_TOKEN }}@github.com/QubitPi/hashicorp-aws-runbooks.git ../hashicorp-aws-runbooks
+      - name: Load Maven settings.xml
+        shell: bash
+        run: cp ../hashicorp-aws-runbooks/paion-data/astraios/settings.xml ~/.m2/settings.xml
       - name: Set up Docker for Integration Tests
         uses: docker-practice/actions-setup-docker@master
       - name: Run unit & integration tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
-<img width="20%" alt="Astraios Logo" src="./docs/static/img/logo.png">
+    <a href="https://www.behance.net/gallery/149763581/Design-Practice-Glass-Planet-Vector-Illustration">
+        <img width="20%" alt="Astraios Logo" src="./docs/static/img/logo.png">
+    </a>
 </div>
 
 Astraios <sup>![Java Version Badge][Java Version Badge]</sup>

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -5,12 +5,12 @@ title: Configuration
 
 The configurations in this page can be set from several sources in the following order:
 
-1. the [operating system's environment variables]; for instance, an environment variable can be set with
-   `export OAUTH_ENABLED="true"`
+1. a **.properties** file placed under CLASSPATH. This file can be put under `src/main/resources` source directory with
+   contents, for example, `OAUTH_ENABLED=true`
 2. the [Java system properties]; for example, a Java system property can be set using
    `System.setProperty("OAUTH_ENABLED", "true")`
-3. a **.properties** file placed under CLASSPATH. This file can be put under `src/main/resources` source directory with
-   contents, for example, `OAUTH_ENABLED=true`
+3. the [operating system's environment variables]; for instance, an environment variable can be set with
+   `export OAUTH_ENABLED="true"`
 
 Core Properties
 ---------------

--- a/src/main/java/com/paiondata/astraios/config/ApplicationConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/ApplicationConfig.java
@@ -27,14 +27,14 @@ import net.jcip.annotations.ThreadSafe;
  * <p>
  * {@link ApplicationConfig} tries to load the configurations from several sources in the following order:
  * <ol>
- *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
- *          operating system's environment variables</a>; for instance, an environment variable can be set with
- *          {@code export EXAMPLE_CONFIG_KEY_NAME="foo"}
+ *     <li> a file named <b>application.properties</b> placed under CLASSPATH. This file can be put under
+ *          {@code src/main/resources} source directory with contents, for example, {@code EXAMPLE_CONFIG_KEY_NAME=foo}
  *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">
  *          Java system properties</a>; for example, a Java system property can
  *          be set using {@code System.setProperty("EXAMPLE_CONFIG_KEY_NAME", "foo")}
- *     <li> a file named <b>oauth.properties</b> placed under CLASSPATH. This file can be put under
- *          {@code src/main/resources} source directory with contents, for example, {@code EXAMPLE_CONFIG_KEY_NAME=foo}
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
+ *          operating system's environment variables</a>; for instance, an environment variable can be set with
+ *          {@code export EXAMPLE_CONFIG_KEY_NAME="foo"}
  * </ol>
  * Note that environment config has higher priority than Java system properties. Java system properties have higher
  * priority than file based configuration.

--- a/src/main/java/com/paiondata/astraios/config/ApplicationConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/ApplicationConfig.java
@@ -42,7 +42,7 @@ import net.jcip.annotations.ThreadSafe;
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"system:env", "system:properties", "classpath:application.properties"})
+@Config.Sources({"classpath:application.properties", "system:properties", "system:env"})
 public interface ApplicationConfig extends Config {
 
     /**

--- a/src/main/java/com/paiondata/astraios/config/JpaDatastoreConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/JpaDatastoreConfig.java
@@ -41,7 +41,7 @@ import net.jcip.annotations.ThreadSafe;
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"system:env", "system:properties", "classpath:jpadatastore.properties"})
+@Config.Sources({"classpath:jpadatastore.properties", "system:env", "system:properties"})
 public interface JpaDatastoreConfig extends Config {
 
     /**

--- a/src/main/java/com/paiondata/astraios/config/JpaDatastoreConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/JpaDatastoreConfig.java
@@ -26,14 +26,14 @@ import net.jcip.annotations.ThreadSafe;
  * <p>
  * {@link JpaDatastoreConfig} tries to load the configurations from several sources in the following order:
  * <ol>
- *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
- *          operating system's environment variables</a>; for instance, an environment variable can be set with
- *          {@code export DB_USER="foo"}
+ *     <li> a file named <b>jpadatastore.properties</b> placed under CLASSPATH. This file can be put under
+ *          {@code src/main/resources} source directory with contents, for example, {@code DB_USER=foo}
  *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">
  *          Java system properties</a>; for example, a Java system property can
  *          be set using {@code System.setProperty("DB_USER", "foo")}
- *     <li> a file named <b>jpadatastore.properties</b> placed under CLASSPATH. This file can be put under
- *          {@code src/main/resources} source directory with contents, for example, {@code DB_USER=foo}
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
+ *          operating system's environment variables</a>; for instance, an environment variable can be set with
+ *          {@code export DB_USER="foo"}
  * </ol>
  * Note that environment config has higher priority than Java system properties. Java system properties have higher
  * priority than file based configuration.
@@ -41,7 +41,7 @@ import net.jcip.annotations.ThreadSafe;
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"classpath:jpadatastore.properties", "system:env", "system:properties"})
+@Config.Sources({"classpath:jpadatastore.properties", "system:properties", "system:env"})
 public interface JpaDatastoreConfig extends Config {
 
     /**

--- a/src/main/java/com/paiondata/astraios/config/OAuthConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/OAuthConfig.java
@@ -41,7 +41,7 @@ import net.jcip.annotations.ThreadSafe;
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"system:env", "system:properties", "classpath:oauth.properties"})
+@Config.Sources({"classpath:oauth.properties", "system:env", "system:properties"})
 public interface OAuthConfig extends Config {
 
     /**

--- a/src/main/java/com/paiondata/astraios/config/OAuthConfig.java
+++ b/src/main/java/com/paiondata/astraios/config/OAuthConfig.java
@@ -26,14 +26,14 @@ import net.jcip.annotations.ThreadSafe;
  * <p>
  * {@link OAuthConfig} tries to load the configurations from several sources in the following order:
  * <ol>
- *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
- *          operating system's environment variables</a>; for instance, an environment variable can be set with
- *          {@code export OAUTH_ENABLED="true"}
+ *     <li> a file named <b>oauth.properties</b> placed under CLASSPATH. This file can be put under
+ *          {@code src/main/resources} source directory with contents, for example, {@code OAUTH_ENABLED=true}
  *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html">
  *          Java system properties</a>; for example, a Java system property can
  *          be set using {@code System.setProperty("OAUTH_ENABLED", "true")}
- *     <li> a file named <b>oauth.properties</b> placed under CLASSPATH. This file can be put under
- *          {@code src/main/resources} source directory with contents, for example, {@code OAUTH_ENABLED=true}
+ *     <li> the <a href="https://docs.oracle.com/javase/tutorial/essential/environment/env.html">
+ *          operating system's environment variables</a>; for instance, an environment variable can be set with
+ *          {@code export OAUTH_ENABLED="true"}
  * </ol>
  * Note that environment config has higher priority than Java system properties. Java system properties have higher
  * priority than file based configuration.
@@ -41,7 +41,7 @@ import net.jcip.annotations.ThreadSafe;
 @Immutable
 @ThreadSafe
 @Config.LoadPolicy(Config.LoadType.MERGE)
-@Config.Sources({"classpath:oauth.properties", "system:env", "system:properties"})
+@Config.Sources({"classpath:oauth.properties", "system:properties", "system:env"})
 public interface OAuthConfig extends Config {
 
     /**

--- a/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
@@ -32,7 +32,7 @@ class DockerComposeITSpec extends AbstractITSpec {
             .withExposedService(
                     "web",
                     WS_PORT,
-                    Wait.forHttp("/v1/data/note").forStatusCode(200)
+                    Wait.forHttp("/v1/data/graph").forStatusCode(200)
             )
 
     @Override
@@ -50,7 +50,7 @@ class DockerComposeITSpec extends AbstractITSpec {
         RestAssured
                 .given()
                 .when()
-                .get("note")
+                .get("graph")
                 .then()
                 .statusCode(200
                 )

--- a/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
+++ b/src/test/groovy/com/paiondata/astraios/application/DockerComposeITSpec.groovy
@@ -32,7 +32,7 @@ class DockerComposeITSpec extends AbstractITSpec {
             .withExposedService(
                     "web",
                     WS_PORT,
-                    Wait.forHttp("/v1/data/graph").forStatusCode(200)
+                    Wait.forHttp("/v1/data/book").forStatusCode(200)
             )
 
     @Override
@@ -50,7 +50,7 @@ class DockerComposeITSpec extends AbstractITSpec {
         RestAssured
                 .given()
                 .when()
-                .get("graph")
+                .get("book")
                 .then()
                 .statusCode(200
                 )


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

~~- Environment variable should be the last resort on searching for config value, not first - https://matteobaccan.github.io/owner/docs/loading-strategies/#:~:text=system%3Aproperties%22%2C-,%22system%3Aenv%22,-%7D)%0Apublic%20interface~~

~~- The advantage of that is during test, we can always make properties file take higher precedence~~

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [ ] Documentation
