### PR TITLE
Temporarily disable sonar scan on fork

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Run unit & integration tests
         run: mvn -B clean verify
       - name: Sonar Scan
+        if: github.ref == 'refs/heads/master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Sonar scan has been turned-off on fork. This is not optimal so it's only going to be temporary. Rather than trying to tackle it, maybe it's time to think about alternatives that can replace SonarCloud because past experience with it is just horrible, including this one

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [x] Test
- [x] Self-review
- [ ] Documentation
