### PR TITLE
Replace cglib with ByteBuddy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,10 +208,9 @@
             <scope>test</scope>
         </dependency>
         <dependency> <!-- Enable mocking of non-interface types -->
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>3.3.0</version>
-            <scope>test</scope>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>1.14.11</version>
         </dependency>
         <dependency>
             <groupId>org.objenesis</groupId>


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Replaced test mocking lib cglib with ByteBuddy as [suggested](https://github.com/cglib/cglib#:~:text=IMPORTANT%20NOTE%3A%20cglib%20is%20unmaintained%20and%20does%20not%20work%20well%20(or%20possibly%20at%20all%3F)%20in%20newer%20JDKs%2C%20particularly%20JDK17%2B.%20If%20you%20need%20to%20support%20newer%20JDKs%2C%20we%20will%20accept%20well%2Dtested%20well%2Dthought%2Dout%20patches...%20but%20you%27ll%20probably%20have%20better%20luck%20migrating%20to%20something%20like%20ByteBuddy.)

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
