### PR TITLE
Resolve some issues with script runtime

### DIFF
--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -83,7 +83,7 @@ public class Book {
 :::tip
 
 Models are usually packaged as **JAR** file in a separate Maven project. Here is a complete
-[example](https://github.com/QubitPi/jersey-webservice-template-jpa-data-models)
+[example](https://github.com/paion-data/astraios-data-models-example)
 
 :::
 
@@ -91,11 +91,11 @@ In the end, run `mvn clean install` to install our model
 
 :::info
 
-From this point on, we assume [this example data model][jersey-webservice-template-jpa-data-models] is used
+From this point on, we assume [this example data model][astraios-data-models-example] is used
 
 ```bash
-git clone https://github.com/QubitPi/jersey-webservice-template-jpa-data-models.git
-cd jersey-webservice-template-jpa-data-models
+git clone https://github.com/paion-data/astraios-data-models-example.git
+cd astraios-data-models-example.git
 mvn clean install
 ```
 
@@ -117,8 +117,8 @@ load [data models](#creating-models) via Maven config file, i.e. **~/.m2/setting
         <profile>
             <id>astraios-data-models</id>
             <properties>
-                <model.package.jar.group.id>com.qubitpi</model.package.jar.group.id>
-                <model.package.jar.artifact.id>jersey-webservice-template-jpa-data-models</model.package.jar.artifact.id>
+                <model.package.jar.group.id>com.paiondata</model.package.jar.group.id>
+                <model.package.jar.artifact.id>astraios-data-models-example</model.package.jar.artifact.id>
                 <model.package.jar.version>1.0.0</model.package.jar.version>
             </properties>
         </profile>
@@ -138,13 +138,13 @@ With data models defined, can run _my-webservice_
 ```bash
 cd my-webservice
 mvn clean package
-MODEL_PACKAGE_NAME=com.qubitpi.ws.jersey.template.models docker compose up --build --force-recreate
+MODEL_PACKAGE_NAME=com.paiondata.astraios.data.models docker compose up --build --force-recreate
 ```
 
 :::info
 
-`com.qubitpi.ws.jersey.template.models` is the name of the model in the aforementioned
-[data model project][jersey-webservice-template-jpa-data-models]
+`com.paiondata.astraios.data.models` is the name of the model in the aforementioned
+[data model project][astraios-data-models-example]
 
 :::
 
@@ -314,5 +314,5 @@ our users is just as easy as it is to add new data. Let's update our model with 
 
 [JAX-RS]: https://jcp.org/en/jsr/detail?id=370
 [Jersey]: https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/index.html
-[jersey-webservice-template-jpa-data-models]: https://github.com/QubitPi/jersey-webservice-template-jpa-data-models
+[astraios-data-models-example]: https://github.com/paion-data/astraios-data-models-example
 [Jetty]: https://eclipse.dev/jetty/

--- a/docs/i18n/zh-cn/docusaurus-plugin-content-docs/current/intro.mdx
+++ b/docs/i18n/zh-cn/docusaurus-plugin-content-docs/current/intro.mdx
@@ -82,7 +82,7 @@ public class Book {
 :::tip
 
 模型通常打包为一个单独 Maven 项目中的 **JAR** 文件。以下是一个
-完整的[示例](https://github.com/QubitPi/jersey-webservice-template-jpa-data-models)
+完整的[示例](https://github.com/paion-data/astraios-data-models-example)
 
 :::
 
@@ -90,11 +90,11 @@ public class Book {
 
 :::info
 
-在这之后，我们使用[这个示例数据模型][jersey-webservice-template-jpa-data-models]
+在这之后，我们使用[这个示例数据模型][astraios-data-models-example]
 
 ```bash
-git clone https://github.com/QubitPi/jersey-webservice-template-jpa-data-models.git
-cd jersey-webservice-template-jpa-data-models
+git clone https://github.com/paion-data/astraios-data-models-example.git
+cd astraios-data-models-example.git
 mvn clean install
 ```
 
@@ -117,8 +117,8 @@ mvn clean install
         <profile>
             <id>astraios-data-models</id>
             <properties>
-                <model.package.jar.group.id>com.qubitpi</model.package.jar.group.id>
-                <model.package.jar.artifact.id>jersey-webservice-template-jpa-data-models</model.package.jar.artifact.id>
+                <model.package.jar.group.id>com.paiondata</model.package.jar.group.id>
+                <model.package.jar.artifact.id>astraios-data-models-example</model.package.jar.artifact.id>
                 <model.package.jar.version>1.0.0</model.package.jar.version>
             </properties>
         </profile>
@@ -138,12 +138,12 @@ mvn clean install
 ```bash
 cd my-webservice
 mvn clean package
-MODEL_PACKAGE_NAME=com.qubitpi.ws.jersey.template.models docker compose up --build --force-recreate
+MODEL_PACKAGE_NAME=com.paiondata.astraios.data.models docker compose up --build --force-recreate
 ```
 
 :::info
 
-`com.qubitpi.ws.jersey.template.models` 是之前提到的[数据模型包][jersey-webservice-template-jpa-data-models]名称
+`com.paiondata.astraios.data.models` 是之前提到的[数据模型包][astraios-data-models-example]名称
 
 :::
 
@@ -311,5 +311,5 @@ MODEL_PACKAGE_NAME=com.qubitpi.ws.jersey.template.models docker compose up --bui
 
 [JAX-RS]: https://jcp.org/en/jsr/detail?id=370
 [Jersey]: https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/index.html
-[jersey-webservice-template-jpa-data-models]: https://github.com/QubitPi/jersey-webservice-template-jpa-data-models
+[astraios-data-models-example]: https://github.com/paion-data/astraios-data-models-example
 [Jetty]: https://eclipse.dev/jetty/

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -16,6 +16,7 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+rm -rf jersey-webservice-template-jpa-data-models
 git clone https://github.com/QubitPi/jersey-webservice-template-jpa-data-models.git
 cd jersey-webservice-template-jpa-data-models
 mvn clean install
@@ -44,6 +45,7 @@ cat >settings.xml <<'EOT'
 </settings>
 EOT
 
+rm -rf astraios
 git clone https://github.com/paion-data/astraios.git
 cd astraios
 mvn --settings ../settings.xml clean package

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -16,8 +16,8 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-rm -rf jersey-webservice-template-jpa-data-models
-git clone https://github.com/QubitPi/jersey-webservice-template-jpa-data-models.git
+rm -rf astraios-data-models-example
+git clone https://github.com/paion-data/astraios-data-models-example.git
 cd jersey-webservice-template-jpa-data-models
 mvn clean install
 cd ../


### PR DESCRIPTION
## Description
If the folder is not empty, the cloning of the repository to local is terminated.
This situation usually occurs after the first successful cloning, the program execution down encountered an exception, then the second time to run the script will appear`destination path xxx already exists and is not an empty directory`.
![1714360409266](https://github.com/paion-data/astraios/assets/164460473/32fca627-3893-4e3b-96ba-55a6d2411923)

## Solution
Delete the directory before each clone.