### PR TITLE
Remove 'No Spring' disclosure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   yml-md-style-and-link-checks:
-    uses: paion-data/ci-cd-core/.github/workflows/yml-md-style-and-link-checks.yml@master
+    uses: paion-data/immutable-infrastructure-as-a-service/.github/workflows/yml-md-style-and-link-checks.yml@master
 
   tests:
     name: Unit & Integration Tests

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -20,15 +20,6 @@ title: Getting Started
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::caution
-
-Before proceeding, it is important to note that **we DO NOT support Spring/Spring Boot paradigm**. [Astraios] runs as a
-**[JAX-RS]** webservice backed by its reference implementation [Jersey] running as a WAR inside [Jetty] container.
-
-More info about difference between JAX-RS and Spring can be found in [this thread](https://stackoverflow.com/a/42955575)
-
-:::
-
 So You Want An API?
 -------------------
 
@@ -312,7 +303,4 @@ our users is just as easy as it is to add new data. Let's update our model with 
 [Astraios]: https://astraios.io/
 [Astraios GitHub]: https://github.com/paion-data/astraios
 
-[JAX-RS]: https://jcp.org/en/jsr/detail?id=370
-[Jersey]: https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/index.html
 [astraios-data-models-example]: https://github.com/paion-data/astraios-data-models-example
-[Jetty]: https://eclipse.dev/jetty/


### PR DESCRIPTION
Changelog
---------

### Added

### Changed

- Due to https://github.com/paion-data/astraios/pull/123, the documentation should be updated by removing the "No Spring support" statement

### Deprecated

### Removed

### Fixed

### Security

Checklist
---------

- [ ] Test
- [ ] Self-review
- [ ] Documentation
